### PR TITLE
Display warnings and act accordingly if the lessons change

### DIFF
--- a/showmehow/remindmehow.py
+++ b/showmehow/remindmehow.py
@@ -22,7 +22,8 @@ from gi.repository import (Gio, Showmehow)
 from showmehow import (create_service,
                        practice_task,
                        print_lines_slowly,
-                       show_tasks)
+                       show_tasks,
+                       ReloadMonitor)
 
 
 def main(argv=None):
@@ -53,4 +54,6 @@ def main(argv=None):
             print_lines_slowly("You've done the following tasks:")
         return show_tasks(known_tasks)
 
-    return practice_task(service, *task)
+    with ReloadMonitor(service) as monitor:
+        return practice_task(service, monitor, *task)
+


### PR DESCRIPTION
`showmehow-service` now has the ability to watch the lesson plan and tell clients that the lessons changed. That might be relevant for nonblocking apps which could just restart the lesson, but for us, we're blocking, so just monitor if the signal happened and terminate accordingly.

`showmehow-serivce` also got the ability to display warnings from the lesson plan, if lessons failed to load for some reason. This will be useful to designers and narrative-developers, so display those warnings at first opportunity.
