### PR TITLE
showmehow: Just call sys.exit() when quitting showmehow

### DIFF
--- a/showmehow/showmehow.py
+++ b/showmehow/showmehow.py
@@ -252,7 +252,7 @@ class PracticeTaskStateMachine(object):
     def quit(self):
         """Quit the main loop and print message."""
         print('See you later!')
-        self._loop.quit()
+        sys.exit(0)
 
     def handle_lessons_changed(self, *args):
         """Handle lessons changing underneath us."""


### PR DESCRIPTION
We don't care about shutting down cleanly. It seems like the loop
does not properly exit when we are calling quit() from within
the input handler.

https://phabricator.endlessm.com/T15148