### PR TITLE
schema: remove python_lists and python_gi

### DIFF
--- a/data/com.endlessm.showmehow.gschema.xml
+++ b/data/com.endlessm.showmehow.gschema.xml
@@ -2,7 +2,7 @@
 <schemalist>
   <schema path="/com/endlessm/showmehow/" id="com.endlessm.showmehow">
     <key name='unlocked-lessons' type='as'>
-      <default>['showmehow', 'fortune', 'readfile', 'breakit', 'changesetting', 'navigation', 'text', 'ps', 'python', 'python_lists', 'python_gi']</default>
+      <default>['showmehow', 'fortune', 'readfile', 'breakit', 'changesetting', 'navigation', 'text', 'ps', 'python']</default>
       <summary>Unlocked lessons</summary>
       <description>
         Lessons which have been unlocked and are available to the user.


### PR DESCRIPTION
As per ticket suggestion: remove python_lists and python_gi from unlocked lessons.
https://phabricator.endlessm.com/T16157