### PR TITLE
showmehow: Read correct variable name

### DIFF
--- a/showmehow/showmehow.py
+++ b/showmehow/showmehow.py
@@ -521,7 +521,7 @@ def get_unlocked_tasks(lessons):
             task_name_detail_pairs[t].level
         ]
         for t in settings.get_value('unlocked-lessons')
-        if t in task_name_desc_pairs and t in task_name_entry_pairs
+        if t in task_name_detail_pairs
     ]
 
 


### PR DESCRIPTION
This happened due to a merge that went in looking at the wrong
varible name.

https://phabricator.endlessm.com/T16189